### PR TITLE
Edit and delete notes

### DIFF
--- a/lmn/forms.py
+++ b/lmn/forms.py
@@ -19,6 +19,12 @@ class NewNoteForm(forms.ModelForm):
         model = Note
         fields = ('title', 'text')
 
+# Added form to edit notes
+class EditNoteForm(forms.ModelForm):
+    class Meta:
+        model = Note
+        fields = ('title', 'text')
+
 
 class UserRegistrationForm(UserCreationForm):
 

--- a/lmn/templates/lmn/notes/delete_note.html
+++ b/lmn/templates/lmn/notes/delete_note.html
@@ -1,0 +1,22 @@
+<!-- 
+    This page confirms the user wants to delete the note.
+ -->
+{% extends 'lmn/base.html' %}
+{% block content %}
+
+
+<h2 id="note_page_title">{{ note.show.artist.name }} at {{ note.show.venue.name }} by <a href="{% url 'lmn:user_profile' user_pk=note.user.pk %}">{{ user.username }}</a></h2>
+
+<p id="note_title"><b>{{ note.title}}</b></p>
+<p id="note_text">{{ note.text }}</b>
+
+<!-- Clicking "Yes" will delete note.
+     Clicking "Cancel" will not delete and go back to previous page
+-->
+<form action="." method="POST">{% csrf_token %}
+    <h3>Are you sure you want to delete this note?</h3>
+    <p><input type='submit' value='Yes'><input type=submit value='Cancel' onclick="javascript:history.back()"></p>
+</form>
+
+
+{% endblock %}

--- a/lmn/templates/lmn/notes/edit_note.html
+++ b/lmn/templates/lmn/notes/edit_note.html
@@ -12,5 +12,9 @@
         <P>
         <input type='submit' value='Update Note'>
     </form>
+    <P>
+    <form action="{% url 'lmn:delete_note' note_pk=note.pk %}">
+        <input id="delete_note" type='submit' value='Delete Note'>
+    </form>
 
 {% endblock %}

--- a/lmn/templates/lmn/notes/edit_note.html
+++ b/lmn/templates/lmn/notes/edit_note.html
@@ -1,0 +1,16 @@
+<!-- 
+    This page allows the user to edit their notes and update them.
+ -->
+{% extends 'lmn/base.html' %}
+{% block content %}
+
+
+<h2 id="note_page_title">{{ note.show.artist.name }} at {{ note.show.venue.name }} by <a href="{% url 'lmn:user_profile' user_pk=note.user.pk %}">{{ user.username }}</a></h2>
+
+    <form method="POST" action="{% url 'lmn:edit_note' note_pk=note.pk %}">{% csrf_token %}
+        {{ form.as_p }}
+        <P>
+        <input type='submit' value='Update Note'>
+    </form>
+
+{% endblock %}

--- a/lmn/templates/lmn/notes/note_detail.html
+++ b/lmn/templates/lmn/notes/note_detail.html
@@ -15,6 +15,9 @@
     <form action="{% url 'lmn:edit_note' note_pk=note.pk %}">
       <input id="edit_note" type='submit' value='Edit note'>
     </form>
+    <form action="{%url 'lmn:delete_note' note_pk=note.pk %}">
+        <input id="delete_note" type='submit' value='Delete Note'>
+    </form>
   
 {% endif %}
 

--- a/lmn/templates/lmn/notes/note_detail.html
+++ b/lmn/templates/lmn/notes/note_detail.html
@@ -7,4 +7,15 @@
 <p id="note_title"><b>{{ note.title}}</b></p>
 <p id="note_text">{{ note.text }}</b>
 
+<!-- 
+    Added the ability to click and edit the note from the note_detail page
+ -->
+{% if note.user.username == user.username %}
+
+    <form action="{% url 'lmn:edit_note' note_pk=note.pk %}">
+      <input id="edit_note" type='submit' value='Edit note'>
+    </form>
+  
+{% endif %}
+
 {% endblock %}

--- a/lmn/templates/lmn/notes/note_list.html
+++ b/lmn/templates/lmn/notes/note_list.html
@@ -18,12 +18,16 @@
   <p class='note_text'>{{ note.text|truncatechars:100 }}</p>
   
   <!-- 
-      If the note was created by the logged in user, an edit note button will appear underneath the note
+      If the note was created by the logged in user, an edit note button
+      and a delete note button will appear underneath the note
    -->
   {% if note.user.username == user.username %}
 
     <form action="{% url 'lmn:edit_note' note_pk=note.pk %}">
-      <input id="edit_note" type='submit' value='Edit note'>
+      <input id="edit_note" type='submit' value='Edit Note'>
+    </form>
+    <form action="{%url 'lmn:delete_note' note_pk=note.pk %}">
+      <input id="delete_note" type='submit' value='Delete Note'>
     </form>
   
   {% endif %}

--- a/lmn/templates/lmn/notes/note_list.html
+++ b/lmn/templates/lmn/notes/note_list.html
@@ -16,7 +16,20 @@
   <p class="show_info"><a href="{% url 'lmn:notes_for_show' show_pk=note.show.pk %}">{{ note.show.artist.name }} at {{ note.show.venue.name }} on {{ note.show.show_date }}</a></p>
   <P class="note_info">Posted on {{ note.posted_date }} by <a class='user' href="{% url 'lmn:user_profile' user_pk=note.user.pk %}">{{ note.user.username }}</a></p>
   <p class='note_text'>{{ note.text|truncatechars:100 }}</p>
+  
+  <!-- 
+      If the note was created by the logged in user, an edit note button will appear underneath the note
+   -->
+  {% if note.user.username == user.username %}
+
+    <form action="{% url 'lmn:edit_note' note_pk=note.pk %}">
+      <input id="edit_note" type='submit' value='Edit note'>
+    </form>
+  
+  {% endif %}
+
   <hr>
+
 
 {% empty %}
 

--- a/lmn/urls.py
+++ b/lmn/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path('notes/detail/<int:note_pk>/', views_notes.note_detail, name='note_detail'),
     path('notes/for_show/<int:show_pk>/', views_notes.notes_for_show, name='notes_for_show'),
     path('notes/add/<int:show_pk>/', views_notes.new_note, name='new_note'),
+    path('notes/edit/<int:note_pk>/', views_notes.edit_note, name='edit_note'),  # Added for editing notes
 
     # Artist related
     path('artists/list/', views_artists.artist_list, name='artist_list'),

--- a/lmn/urls.py
+++ b/lmn/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('notes/for_show/<int:show_pk>/', views_notes.notes_for_show, name='notes_for_show'),
     path('notes/add/<int:show_pk>/', views_notes.new_note, name='new_note'),
     path('notes/edit/<int:note_pk>/', views_notes.edit_note, name='edit_note'),  # Added for editing notes
+    path('notes/delete/<int:note_pk>/', views_notes.delete_note, name='delete_note'),  # Added for deleting notes
 
     # Artist related
     path('artists/list/', views_artists.artist_list, name='artist_list'),

--- a/lmn/views_notes.py
+++ b/lmn/views_notes.py
@@ -64,3 +64,15 @@ def edit_note(request, note_pk):
         form = EditNoteForm(instance=note)
 
     return render(request, 'lmn/notes/edit_note.html', { 'form': form, 'note': note })
+
+
+def delete_note(request, note_pk):
+    note = get_object_or_404(Note, pk=note_pk)
+
+    if request.method == 'POST':
+        note.delete()
+        return redirect('lmn:latest_notes')
+    context = {
+        'note': note,
+    }
+    return render(request, 'lmn/notes/delete_note.html', context)

--- a/lmn/views_notes.py
+++ b/lmn/views_notes.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 
 from .models import Venue, Artist, Note, Show
-from .forms import VenueSearchForm, NewNoteForm, ArtistSearchForm, UserRegistrationForm
+from .forms import VenueSearchForm, NewNoteForm, ArtistSearchForm, UserRegistrationForm, EditNoteForm
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -46,3 +46,21 @@ def notes_for_show(request, show_pk):   # pk = show pk
 def note_detail(request, note_pk):
     note = get_object_or_404(Note, pk=note_pk)
     return render(request, 'lmn/notes/note_detail.html' , { 'note': note })
+
+# Added function to edit notes 
+def edit_note(request, note_pk):
+    note = get_object_or_404(Note, pk=note_pk)
+
+    if request.method == 'POST' :
+
+        form = EditNoteForm(request.POST, instance=note)
+        if form.is_valid():
+            note = form.save(commit=False)
+            note.save()
+            return redirect('lmn:note_detail', note_pk=note.pk)  # After note is updated redirect to the note_detail page
+
+    else:
+        # New edit note form with current note details (Ex. Title, Text)
+        form = EditNoteForm(instance=note)
+
+    return render(request, 'lmn/notes/edit_note.html', { 'form': form, 'note': note })


### PR DESCRIPTION
Added the ability to edit notes once they are made and delete them.
Buttons to edit and delete only visible to user that created them.
Added to the latest notes page, note detail page and edit note pages.

Issue #9